### PR TITLE
Add description

### DIFF
--- a/api/main.go
+++ b/api/main.go
@@ -64,6 +64,7 @@ type SegmentAndId struct {
 	IsChecked   bool
 	SegmentName string
 	SegmentID   string
+	Description string
 }
 
 type ContactInfoByEmail struct {
@@ -124,7 +125,13 @@ func getSegmentAndIdInfo(w http.ResponseWriter, r *http.Request) {
 			// Append segment and ID to output
 			for _, value := range data.Lists {
 				_, isSubscribed := contactSegments[strconv.Itoa(value.ID)]
-				curSegmentAndId := SegmentAndId{isSubscribed, value.Name, strconv.Itoa(value.ID)}
+
+				description := ""
+
+				if descriptionExists(value.Description) {
+					description = value.Description.(string)
+				}
+				curSegmentAndId := SegmentAndId{isSubscribed, value.Name, strconv.Itoa(value.ID), description}
 				contactSegmentsAndIds.SegmentsAndIds = append(contactSegmentsAndIds.SegmentsAndIds, curSegmentAndId)
 			}
 
@@ -137,6 +144,15 @@ func getSegmentAndIdInfo(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+}
+
+func descriptionExists(description interface{}) bool {
+	switch description.(type) {
+	default:
+		return false
+	case string:
+		return true
+	}
 }
 
 func getContactIdByEmail(w http.ResponseWriter, r *http.Request, contactEmail string) string {

--- a/src/containers/Subscription.css
+++ b/src/containers/Subscription.css
@@ -1,8 +1,8 @@
 .displayMessage {
-    font-size: 18px;
+  font-size: 18px;
 }
 .checkboxContainer {
-    width: 200px;
+    width: 700px;
     margin: auto;
     position: relative;
     padding-bottom: 25px;
@@ -10,7 +10,7 @@
 }
 
 .checkboxContent {
-    text-align: left;
+  text-align: justify;
 }
 
 .segmentNames {
@@ -31,7 +31,7 @@
     -ms-user-select: none;
     user-select: none;
   }
-  
+
   /* Hide the browser's default checkbox */
   .checkbox input {
     position: absolute;
@@ -40,24 +40,22 @@
     height: 0;
     width: 0;
   }
-  
+
   /* Create a custom checkbox */
   .checkmark {
     position: absolute;
     -ms-transform: translateY(-50%);
     transform: translateY(-50%);
-    top: 50%;
-    left: 0;
+    left: 0px;
+    top: 13.5px;
     height: 18px;
     width: 18px;
     outline: 2px solid #606060;
   }
-  
   /* When the checkbox is checked, add a blue background */
   .checkbox input:checked ~ .checkmark {
     background-color: #606060;
   }
-  
   /* Create the checkmark/indicator (hidden when not checked) */
   .checkmark:after {
     content: "\2713";
@@ -68,7 +66,6 @@
     transform: translate(-50%, -50%);
     display: none;
   }
-  
   /* Show the checkmark when checked */
   .checkbox input:checked ~ .checkmark:after {
     display: block;

--- a/src/containers/Subscription.css
+++ b/src/containers/Subscription.css
@@ -70,3 +70,9 @@
   .checkbox input:checked ~ .checkmark:after {
     display: block;
   }
+
+  @media screen and (max-width: 800px) {
+    .checkboxContainer {
+       width: 100%;
+    }
+ }

--- a/src/containers/Subscription.js
+++ b/src/containers/Subscription.js
@@ -41,7 +41,7 @@ export const Subscription = () => {
             {segments.map((contents, x) => (
               <div key={contents.segmentID} className="checkboxContent"> 
                 <label className="checkbox" htmlFor={contents.segmentID}>
-                  {contents.segmentName}
+                  {contents.segmentName} {contents.description ? `- ${contents.description}` : ""} 
                   <input type="checkbox" id ={contents.segmentID} checked={contents.isChecked} onChange={() => handleCheckbox(x)}/>
                   <span className="checkmark"></span>
                 </label>
@@ -121,7 +121,8 @@ export const Subscription = () => {
           const segmentObjects = segmentData.segmentsAndIds.map((contents) => ({
             isChecked: contents.IsChecked,
             segmentID: contents.SegmentID,
-            segmentName: contents.SegmentName
+            segmentName: contents.SegmentName,
+            description: contents.Description
           }));
           
           setSegments(segmentObjects.sort((segmentA, segmentB) => segmentA.segmentName.localeCompare(segmentB.segmentName)));


### PR DESCRIPTION
- Add description field for the endpoint "segments" in the Subscription Service API
- Add description field in front end to follow segment name in the subscription page.

- Change checkbox to appear on top row

Example: 
- [ ] Andrew's Segment - This mailing list includes updates about major upcoming changes on the
Platform, important information for the product teams and updates about Platform outages.