### PR TITLE
Registry integration doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Summary
 This document contains the developer documentation of the Mautic email subscription app. For knowledge and files related to the Mautic server, refer to this repo https://github.com/bcgov/Mautic-Openshift.
 
+For more information on how Mautic integrates into other Platform services, please refer to [additional docs](./docs/registry-mautic-integration.md).
+
 # Architecture Diagram
 
 ![Architecture Diagram](architecture-diagram.png)

--- a/docs/registry-mautic-integration.md
+++ b/docs/registry-mautic-integration.md
@@ -1,0 +1,23 @@
+# Registry and Mautic Integration
+
+We use Mautic to send out important notification emails to all Product Owners and Technical Leads from Private/Public Cloud Platforms. Registry being the front door recording POs and TLs' contact information, Mautic relies on it to keep the email contact update-to-date. When Mautic receives request from Registry, it'll decide which email segment to add the new contact into.
+
+## Flow of the integration
+```mermaid
+sequenceDiagram
+    participant Registry
+    participant Mautic Custom API endpoint
+    participant Mautic Server endpoint
+    Registry->>Mautic Custom API endpoint: PO/TL's contact information:<br />- First Name<br />- Last Name<br />- Email<br />- Platform & Cluster Name
+    Mautic Custom API endpoint->>Mautic Server endpoint: Create/Update contact in a specific Segment
+    Note right of Mautic Custom API endpoint: Cluster to Segment Relationship
+```
+
+### Cluster to Segment Relationship:
+
+| Platform | Cluster | Segment |
+|---|---|---|
+| Private Cloud | Silver | critical-updates-generic, critical-updates-silver |
+| Private Cloud | Gold & Golddr |critical-updates-generic, critical-updates-gold |
+| Private Cloud | Emerald |critical-updates-generic, critical-updates-emerald |
+| Public Cloud | AXS | public-cloud-accelerator-updates |

--- a/docs/registry-mautic-integration.md
+++ b/docs/registry-mautic-integration.md
@@ -17,7 +17,7 @@ sequenceDiagram
 
 | Platform | Cluster | Segment |
 |---|---|---|
-| Private Cloud | Silver | critical-updates-generic, critical-updates-silver |
-| Private Cloud | Gold & Golddr |critical-updates-generic, critical-updates-gold |
-| Private Cloud | Emerald |critical-updates-generic, critical-updates-emerald |
-| Public Cloud | AXS | public-cloud-accelerator-updates |
+| Private Cloud | Silver | critical-updates-generic, critical-updates-silver, platform-comms |
+| Private Cloud | Gold & Golddr |critical-updates-generic, critical-updates-gold, platform-comms |
+| Private Cloud | Emerald |critical-updates-generic, critical-updates-emerald, platform-comms |
+| Public Cloud | AWS | public-cloud-accelerator-updates |


### PR DESCRIPTION
brief doc to explain the integration between Registry and Mautic for critical update segments. @blueQcloud I've confirmed with Sal, let's have a generic critical update segment that includes all the POs and TLs from Private Cloud, in addition to the cluster-based segments!